### PR TITLE
📖 책(Book) 삭제 API

### DIFF
--- a/services/book-service/src/main/kotlin/com/example/bookstore/book/adapter/in/web/BookController.kt
+++ b/services/book-service/src/main/kotlin/com/example/bookstore/book/adapter/in/web/BookController.kt
@@ -5,11 +5,13 @@ import com.example.bookstore.book.adapter.`in`.web.request.UpdateBookRequest
 import com.example.bookstore.book.adapter.`in`.web.response.SaveBookResponse
 import com.example.bookstore.book.adapter.`in`.web.response.UpdateBookResponse
 import com.example.bookstore.book.adapter.`in`.web.support.ApiResponse
+import com.example.bookstore.book.application.port.`in`.DeleteBookUseCase
 import com.example.bookstore.book.application.port.`in`.SaveBookCommand
 import com.example.bookstore.book.application.port.`in`.SaveBookUseCase
 import com.example.bookstore.book.application.port.`in`.UpdateBookCommand
 import com.example.bookstore.book.application.port.`in`.UpdateBookUseCase
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -23,7 +25,8 @@ import java.net.URI
 @RequestMapping("/api/v1/books")
 class BookController(
     private val saveBookUseCase: SaveBookUseCase,
-    private val updateBookUseCase: UpdateBookUseCase
+    private val updateBookUseCase: UpdateBookUseCase,
+    private val deleteBookUseCase: DeleteBookUseCase
 ) {
 
     @PostMapping
@@ -79,4 +82,11 @@ class BookController(
             )
         )
     }
+
+    @DeleteMapping("/{bookId}")
+    fun delete(@PathVariable bookId: Long): ResponseEntity<ApiResponse<Void>> {
+        deleteBookUseCase.execute(bookId)
+        return ResponseEntity.noContent().build()
+    }
+
 }

--- a/services/book-service/src/main/kotlin/com/example/bookstore/book/adapter/out/persistent/BookPersistentAdapter.kt
+++ b/services/book-service/src/main/kotlin/com/example/bookstore/book/adapter/out/persistent/BookPersistentAdapter.kt
@@ -3,6 +3,7 @@ package com.example.bookstore.book.adapter.out.persistent
 import Snowflake
 import com.example.bookstore.book.adapter.out.persistent.entity.BookEntity
 import com.example.bookstore.book.adapter.out.persistent.repository.JpaBookRepository
+import com.example.bookstore.book.application.port.out.DeleteBookPort
 import com.example.bookstore.book.application.port.out.LoadBookPort
 import com.example.bookstore.book.application.port.out.SaveBookPort
 import com.example.bookstore.book.domain.Book
@@ -13,7 +14,7 @@ import java.time.LocalDateTime
 @Component
 class BookPersistentAdapter(
     private val jpaBookRepository: JpaBookRepository,
-) : SaveBookPort, LoadBookPort{
+) : SaveBookPort, LoadBookPort, DeleteBookPort {
 
     private val snowflake = Snowflake()
 
@@ -55,5 +56,14 @@ class BookPersistentAdapter(
             createdAt = bookEntity.createdAt,
             updatedAt = bookEntity.updatedAt
         )
+    }
+
+    override fun delete(bookId: Long) {
+
+        val book = jpaBookRepository.findById(bookId).orElseThrow {
+            IllegalArgumentException("Book not found with id: $bookId")
+        }
+
+        jpaBookRepository.delete(book)
     }
 }

--- a/services/book-service/src/main/kotlin/com/example/bookstore/book/application/port/in/DeleteBookUseCase.kt
+++ b/services/book-service/src/main/kotlin/com/example/bookstore/book/application/port/in/DeleteBookUseCase.kt
@@ -1,0 +1,7 @@
+package com.example.bookstore.book.application.port.`in`
+
+
+
+interface DeleteBookUseCase {
+    fun execute(bookId: Long)
+}

--- a/services/book-service/src/main/kotlin/com/example/bookstore/book/application/port/out/DeleteBookPort.kt
+++ b/services/book-service/src/main/kotlin/com/example/bookstore/book/application/port/out/DeleteBookPort.kt
@@ -1,0 +1,7 @@
+package com.example.bookstore.book.application.port.out
+
+import com.example.bookstore.book.domain.Book
+
+interface DeleteBookPort {
+    fun delete(bookId: Long)
+}

--- a/services/book-service/src/main/kotlin/com/example/bookstore/book/application/service/DeleteBookService.kt
+++ b/services/book-service/src/main/kotlin/com/example/bookstore/book/application/service/DeleteBookService.kt
@@ -1,0 +1,17 @@
+package com.example.bookstore.book.application.service
+
+import com.example.bookstore.book.application.port.`in`.DeleteBookUseCase
+import com.example.bookstore.book.application.port.out.DeleteBookPort
+import com.example.bookstore.book.application.port.out.LoadBookPort
+import org.springframework.stereotype.Service
+
+
+@Service
+class DeleteBookService(
+    private val deleteBookPort: DeleteBookPort
+) : DeleteBookUseCase {
+
+    override fun execute(bookId: Long) {
+        deleteBookPort.delete(bookId)
+    }
+}


### PR DESCRIPTION

# 📖 책(Book) 삭제 API 구현

## ✨ 주요 변경사항
- `DELETE /api/v1/books/{bookId}` API 추가
- 헥사고날 아키텍처(Hexagonal Architecture, 포트-어댑터 패턴) 적용
- `RestAssuredMockMvc` + `Spring REST Docs` 기반 통합 테스트 작성 및 문서화

---

## 🚀 API 스펙

### HTTP 메소드 및 엔드포인트
---

### 📌 Path Parameters

| Parameter | Type | Description |
|:----------|:-----|:------------|
| `bookId`  | Long | 삭제할 책 ID |

---

### 📥 요청(Request) Body
- 없음

---

### 📤 응답(Response)

- **HTTP Status Code**: `204 No Content`
- **Response Body**: 없음

---